### PR TITLE
Implement GET /user/me endpoint to retrieve user details

### DIFF
--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, status
-from app.schemas import UserDetails, UserDetailsUpdatable
+from app.schemas import UserDetails, UserDetailsUpdatable, UserDisplay
 from sqlalchemy.orm import Session
 from app.database import get_db
 from app.database import db_user
@@ -24,3 +24,7 @@ def update_user(email:str = None, password:str = None,db: Session = Depends(get_
 @router.post("/DELETE_USER")
 def delete_user(user : DBUser = Depends(get_curren_user), db:Session = Depends(get_db)):
     return db_user.delete_user(user=user, db=db)
+
+@router.get("/me", response_model=UserDisplay)
+def get_current_user(user: DBUser = Depends(get_curren_user)):
+    return user

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -8,7 +8,7 @@ class UserDetails(UserDetailsUpdatable):
     user_name : str
 
 class UserDisplay(BaseModel):
-    ser_name : str
+    user_name : str
     email : str = None
     class Config():   #to convert the model to this
         from_attributes = True


### PR DESCRIPTION
# Add GET Endpoint to Retrieve User Details

## Description
This PR implements a new GET endpoint `/user/me` that allows authenticated users to retrieve their own user details. This addresses issue #8 where there was no dedicated endpoint to view user information.

## Changes Made
- Added new GET endpoint `/user/me` in [app/routers/user.py]
- The endpoint returns the user's username and email
- Uses the existing authentication system to identify the user

## Testing
The endpoint was tested using cURL with the following steps:

1. Created a test user:
   ```bash
   curl -X 'POST' '[local' \
     -H 'Content-Type: application/json' \
     -d '{"user_name": "testuser", "email": "test@example.com", "password": "password123"}'
2. Obtained Auth Tokin
3. Successfully retrieved user details
4. Response: {"user_name":"testuser","email":"test@example.com"}