### PR TITLE
Fix #7: Add expires_in field to token response with type safety

### DIFF
--- a/app/authentication/auth_router.py
+++ b/app/authentication/auth_router.py
@@ -6,6 +6,7 @@ from app.database import  get_db
 from app.database.models import DBUser
 from app.database.hash import Hash
 from app.authentication.authentication import create_access_token
+from config import Config
 
 
 router = APIRouter(
@@ -30,5 +31,6 @@ def get_token(request: OAuth2PasswordRequestForm = Depends(OAuth2PasswordRequest
     return {
         "access_token": access_token,
         "token_type": "bearer",
+        "expires_in": Config.ACCESS_TOKEN_EXPIRE_MINUTES * 60,  # Convert minutes to seconds
         "user_name": user.user_name
     }

--- a/app/authentication/auth_router.py
+++ b/app/authentication/auth_router.py
@@ -31,6 +31,6 @@ def get_token(request: OAuth2PasswordRequestForm = Depends(OAuth2PasswordRequest
     return {
         "access_token": access_token,
         "token_type": "bearer",
-        "expires_in": Config.ACCESS_TOKEN_EXPIRE_MINUTES * 60,  # Convert minutes to seconds
+        "expires_in": int(Config.ACCESS_TOKEN_EXPIRE_MINUTES) * 60,  # Convert minutes to seconds
         "user_name": user.user_name
     }

--- a/tests/test_users_and_auth.py
+++ b/tests/test_users_and_auth.py
@@ -57,8 +57,10 @@ def test_auth_token_right_credentials():
     
     assert "access_token" in response_json
     assert "token_type" in response_json
+    assert "expires_in" in response_json
     assert response_json["token_type"] == "bearer" 
     assert response_json["user_name"] == "test_username"
+    assert response_json["expires_in"] == 1800  # 30 minutes * 60 seconds
 
 
 

--- a/tests/test_users_and_auth.py
+++ b/tests/test_users_and_auth.py
@@ -1,5 +1,6 @@
 from tests import client
 from tests import access_token
+from config import Config
 
 
 def test_new_user():
@@ -60,7 +61,7 @@ def test_auth_token_right_credentials():
     assert "expires_in" in response_json
     assert response_json["token_type"] == "bearer" 
     assert response_json["user_name"] == "test_username"
-    assert response_json["expires_in"] == 1800  # 30 minutes * 60 seconds
+    assert response_json["expires_in"] == Config.ACCESS_TOKEN_EXPIRE_MINUTES * 60  # Convert minutes to seconds
 
 
 

--- a/tests/test_users_and_auth.py
+++ b/tests/test_users_and_auth.py
@@ -61,7 +61,7 @@ def test_auth_token_right_credentials():
     assert "expires_in" in response_json
     assert response_json["token_type"] == "bearer" 
     assert response_json["user_name"] == "test_username"
-    assert response_json["expires_in"] == Config.ACCESS_TOKEN_EXPIRE_MINUTES * 60  # Convert minutes to seconds
+    assert response_json["expires_in"] == int(Config.ACCESS_TOKEN_EXPIRE_MINUTES) * 60  # Convert minutes to seconds
 
 
 


### PR DESCRIPTION
This PR fixes issue #7 by adding the `expires_in` field to the token response and includes several improvements:

### Changes Made:
1. **Added `expires_in` field** to the token response in `/auth/token` endpoint
2. **Improved test reliability** by using `Config.ACCESS_TOKEN_EXPIRE_MINUTES` instead of hard-coded values
3. **Added type safety** by explicitly casting `Config.ACCESS_TOKEN_EXPIRE_MINUTES` to `int` to handle cases where it might be loaded as a string from environment variables

### Before:
```python
return {
    "access_token": access_token,
    "token_type": "bearer",
    "user_name": user.user_name
}

return {
    "access_token": access_token,
    "token_type": "bearer",
    "expires_in": int(Config.ACCESS_TOKEN_EXPIRE_MINUTES) * 60,  # Convert minutes to seconds
    "user_name": user.user_name
}

Testing:
All tests pass successfully
The token response now includes the expires_in field with the correct value
The code handles cases where ACCESS_TOKEN_EXPIRE_MINUTES might be loaded as a string